### PR TITLE
Fix line and column numbers in YAML parser error message

### DIFF
--- a/src/Data/Yaml/Frontmatter.hs
+++ b/src/Data/Yaml/Frontmatter.hs
@@ -3,7 +3,8 @@ module Data.Yaml.Frontmatter where
 
 import           Data.Attoparsec.ByteString
 import           Data.Frontmatter.Internal
-import           Data.Yaml                  (FromJSON, Value, decodeEither)
+import           Data.Yaml                  (FromJSON, Value, decodeEither', ParseException (InvalidYaml), YamlException (YamlParseException, yamlProblem, yamlProblemMark, yamlContext), YamlMark (yamlLine, yamlColumn))
+import           Data.Yaml.Aeson            (prettyPrintParseException)
 
 -- |
 -- Parses a YAML frontmatter or JSON frontmatter from a 'ByteString' as a
@@ -14,6 +15,18 @@ frontmatterYaml = frontmatterYaml' <?> "frontmatterYaml"
   where
     frontmatterYaml' = do
         f <- frontmatter
-        case decodeEither f of
-            Left e -> fail e
+        case decodeEither' f of
+            Left (InvalidYaml (Just (e0@YamlParseException { yamlProblem = msg, yamlContext = ctx, yamlProblemMark = pos }))) ->
+              let
+                fixedMark =
+                  -- Column and line are both incremented, so they count from 1, as is usual...
+                  pos {
+                    -- ... and an extra increment for the --- marker
+                    yamlLine = yamlLine pos + 2,
+                    yamlColumn = yamlColumn pos + 1
+                  }
+                e = InvalidYaml (Just e0 { yamlProblemMark = fixedMark })
+              in failYaml e
+            Left e -> failYaml e
             Right v -> return v
+    failYaml = fail . prettyPrintParseException

--- a/test/Data/FrontmatterSpec.hs
+++ b/test/Data/FrontmatterSpec.hs
@@ -44,5 +44,8 @@ spec = do
 
         it "handles input with invalid frontmatters" $ do
             input <- ByteString.readFile "./invalid-yaml-frontmatter.md"
-            let Fail input' _ _ = parse frontmatterYaml input :: Result Value
+            let Fail input' _ctx msg = parse frontmatterYaml input :: Result Value
             input' `shouldBe` "etc etc\n"
+            -- ignoring _ctx. Does not appear useful.
+            -- A somewhat different message may be ok, but the line and column must be the same
+            msg `shouldBe` "Failed reading: YAML parse exception at line 2, column 11:\nmapping values are not allowed in this context"


### PR DESCRIPTION
The `---` aren't parsed by the YAML parser, and attoparsec seems to use 0-based indexes, which is not what text editors and their users expect.
